### PR TITLE
Sync via GitHub Actions

### DIFF
--- a/.github/fetch-upstream.sh
+++ b/.github/fetch-upstream.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+# Create a temporary directory.
+# NOTE: We use mktemp, which must be available on Linux.
+temp_dir=$(mktemp -d)
+trap 'rm -rf -- "$temp_dir"' EXIT
+
+# Download the distribution from the upstream and expand it.
+# NOTE: We assume curl and GNU tar are available.
+(
+    cd "$temp_dir"
+    curl -O https://feynrules.irmp.ucl.ac.be/downloads/feynrules-current.tar.gz
+    tar xfz feynrules-current.tar.gz
+)
+
+# Remove all files/directories from the upstream.
+for f in $(ls); do
+  # NOTE: files/directories starting with "." are excluded.
+  [ "$f" == "readme.md" ] && continue
+  rm -fr "$f"
+done
+
+# Copy all files/directories from the distribution.
+for f in $(cd "$temp_dir/feynrules-current" && ls); do
+  cp -fpr "$temp_dir/feynrules-current/$f" .
+done

--- a/.github/make-commit-msg.sh
+++ b/.github/make-commit-msg.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+# extract_value FILE KEY prints VALUE associated with KEY in FILE.
+extract_value() {
+  local file=$1
+  local key=$2
+  # Extract the first "KEY = VALUE" pair and perform regexp match.
+  [[ $(grep "$key" "$file" | grep '=' | head -1) =~ ^[^=]*=(.*)$ ]]
+  # Remove a trailing semicolon and double quotation marks.
+  echo ${BASH_REMATCH[1]} | sed 's/;$//' | sed 's/^"//' | sed 's/"$//'
+}
+
+# Get FR$Version and FR$VersionDate from FeynRulesPackage.m.
+version=$(extract_value FeynRulesPackage.m 'FR$Version')
+version_date=$(extract_value FeynRulesPackage.m 'FR$VersionDate')
+
+# Construct a commit message.
+echo "v$version ($version_date)"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,24 @@
+name: Sync
+
+on:
+  schedule:
+    - cron: 0 0 * * * # daily
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Fetch from the upstream
+        run: .github/fetch-upstream.sh
+
+      - name: Push changes
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git commit -am "$(.github/make-commit-msg.sh)"
+            git push
+          fi

--- a/Core/Initialisation.m
+++ b/Core/Initialisation.m
@@ -81,7 +81,7 @@ NumericalValue[Abs[x_]] := Abs[NumericalValue[x]];
 
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Dot*)
 
 
@@ -226,7 +226,7 @@ numQ /: numQ[a_/b_] := numQ[a] && numQ[b];
 numQ /: numQ[1/a_] := numQ[a];
 numQ /: numQ[f_?(MemberQ[{Sqrt, Exp, Log, Sin, Cos, Tan, Csc, Sec, Cot, ArcSin, ArcCos, ArcTan, ArcCsc, ArcSec, ArcCot, Sinh, Cosh, 
 Tanh, Csch, Sech, Coth, ArcSinh, ArcCosh, ArcTanh, ArcCsch, ArcSech, ArcCoth}, #]&)[a_]] := numQ[a];
-numQ /: numQ[Power[a_, n_]] := numQ[a];
+numQ /: numQ[Power[a_, n_]] := numQ[a] && numQ[n];
 
 numQ[FV[__]] := True;
 

--- a/Core/Loop.m
+++ b/Core/Loop.m
@@ -190,18 +190,7 @@ For[vevkk=1,vevkk<=Length[M$vevs],vevkk++,
   (*switch depending how many physical fields appear in vevfi*)
   Print[InputForm[vevfi]];
   Switch[Length[Cases[vevfi,_?FieldQ,\[Infinity]]],
-    1,tadrules=Cases[vevfi,_?FieldQ,\[Infinity]][[1]];,
     (*shift the scalar or the pseudo scalar depending if the vev has a real or imaginary coefficient*)
-    2,If[Im[Coefficient[vevfi,M$vevs[[vevkk,2]]]]===0,
-       If[Im[Coefficient[vevfi,Cases[vevfi,_?FieldQ,\[Infinity]][[1]]]]===0&&SelfConjugateQ[Cases[vevfi,_?FieldQ,\[Infinity]][[1]]],
-         tadrules=Cases[vevfi,_?FieldQ,\[Infinity]][[1]];,
-         tadrules=Cases[vevfi,_?FieldQ,\[Infinity]][[2]];
-       ],
-       If[Im[Coefficient[vevfi,Cases[vevfi,_?FieldQ,\[Infinity]][[1]]]]===0&&SelfConjugateQ[Cases[vevfi,_?FieldQ,\[Infinity]][[1]]],
-         tadrules=Cases[vevfi,_?FieldQ,\[Infinity]][[2]];,
-         tadrules=Cases[vevfi,_?FieldQ,\[Infinity]][[1]];
-       ];
-     ],
     _,vevfi2=Cases[vevfi,_?FieldQ,\[Infinity]];
     Print["in last case"];
     If[And@@(SelfConjugateQ/@vevfi2),
@@ -228,24 +217,24 @@ For[vevkk=1,vevkk<=Length[M$vevs],vevkk++,
     Cases[M$ClassesDescription,{c___,ClassMembers->{xx___,tadrules[[vevll]],yy___},b___}:>(Mass/.{c,b})[[-Length[{yy}]-1,1]],2]][[1]])^2];
   ];*)
 ];
-Print["after for"];
-Print[InputForm[tadrules]];
+(*Print["after for"];
+Print[InputForm[tadrules]];*)
 vevfi2=Union[Cases[tadrules,_?FieldQ,\[Infinity]]];
-Print[InputForm[vevfi2]];
+(*Print[InputForm[vevfi2]];*)
 tadrules=Solve[(#[[1]]==#[[2]]&)/@tadrules,vevfi2];
 If[Length[tadrules]=!=1,
    Print[Style["Error : no unique solution for the renormalization of the tadpole",Red]];
    Abort[]];
-Print["t1"];
+Print["Fields and corresponding vevs"];
 Print[InputForm[tadrules]];
 tadrules=DeleteCases[tadrules[[1]],Rule[_,0]];
-Print[InputForm[tadrules]];
-Print["t2"];
+(*Print[InputForm[tadrules]];*)
 For[vevll=1,vevll<=Length[tadrules],vevll++,
     tadrep=Append[tadrep,tadrules[[vevll,1]]->tadrules[[vevll,1]]-FR$CT*FR$deltat[tadrules[[vevll,1]]]/( Union[
     Cases[M$ClassesDescription,{c___,ClassName->tadrules[[vevll,1]],b___}:>(Mass/.{c,b})[[1]],2],
     Cases[M$ClassesDescription,{c___,ClassMembers->{xx___,tadrules[[vevll,1]],yy___},b___}:>(Mass/.{c,b})[[-Length[{yy}]-1,1]],2]][[1]])^2];
   ];
+  Print["Tadpole redefinition"];
   Print[InputForm[tadrep]];
 tadrep
 ];

--- a/FeynRulesPackage.m
+++ b/FeynRulesPackage.m
@@ -12,8 +12,8 @@ FR$Loaded = True;
 
 BeginPackage["FeynRules`"];
 
-FR$VersionNumber = "2.3.36";
-FR$VersionDate = "28 November 2019";
+FR$VersionNumber = "2.3.41";
+FR$VersionDate = "09 December 2020";
 
 Print[" - FeynRules - "];
 Print["Version: ", FR$VersionNumber, " ("FR$VersionDate, ")."];

--- a/FeynRulesPackage.m
+++ b/FeynRulesPackage.m
@@ -12,8 +12,8 @@ FR$Loaded = True;
 
 BeginPackage["FeynRules`"];
 
-FR$VersionNumber = "2.3.41";
-FR$VersionDate = "09 December 2020";
+FR$VersionNumber = "2.3.42";
+FR$VersionDate = "14 February 2021";
 
 Print[" - FeynRules - "];
 Print["Version: ", FR$VersionNumber, " ("FR$VersionDate, ")."];

--- a/FeynRulesPackage.m
+++ b/FeynRulesPackage.m
@@ -12,8 +12,8 @@ FR$Loaded = True;
 
 BeginPackage["FeynRules`"];
 
-FR$VersionNumber = "2.3.42";
-FR$VersionDate = "14 February 2021";
+FR$VersionNumber = "2.3.43";
+FR$VersionDate = "23 February 2021";
 
 Print[" - FeynRules - "];
 Print["Version: ", FR$VersionNumber, " ("FR$VersionDate, ")."];

--- a/ToolBox.m
+++ b/ToolBox.m
@@ -414,8 +414,8 @@ CheckHermiticity[lagrangian_, options___] := Block[{tempoptions, results, llag, 
      Print["Checking for hermiticity by calculating the Feynman rules contained in L-HC[L]."];
      Print["If the lagrangian is hermitian, then the number of vertices should be zero."];
      (* Improvements added by Benj *)
-     llag = OptimizeIndex[ExpandIndices[lagrangian]]/.{Eps[argsargs__] :> Signature[{argsargs} ] Eps[Sequence @@ Sort[{argsargs}]]};  (* CD: Added ExpandIndices *)
-     hcllag = OptimizeIndex[ExpandIndices[HC[lagrangian]]]/.{Eps[argsargs__] :> Signature[{argsargs} ] Eps[Sequence @@ Sort[{argsargs}]]};
+     llag = OptimizeIndex[ExpandIndices[lagrangian]]/.{Eps[args1__] :> Signature[{args1} ] Eps[Sequence @@ Sort[{args1}]]};  (* CD: Added ExpandIndices *)
+     hcllag = OptimizeIndex[ExpandIndices[HC[lagrangian]]]/.{Eps[args1__] :> Signature[{args1} ] Eps[Sequence @@ Sort[{args1}]]};
 
      (* End of improvements added by Benj *)
      results = Simplify[FeynmanRules[ llag - hcllag, options, ScreenOutput -> False]];

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -1,5 +1,7 @@
 Update notes for FeynRules 2.3.x
 
+2631 2.3.42 14-02-21 claudeduhr: fixed bug in numQ for exponentials 
+
 2628 2.3.41 09-12-20 claudeduhr: fixed merge conflict 
 
 2626 2.3.40 02-12-20 claudeduhr: nothing 

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -1,5 +1,16 @@
 Update notes for FeynRules 2.3.x
 
+2628 2.3.41 09-12-20 claudeduhr: fixed merge conflict 
+
+2626 2.3.40 02-12-20 claudeduhr: nothing 
+
+2626 2.3.39 02-12-20 claudeduhr: nothing 
+
+2626 2.3.38 02-12-20 claudeduhr: nothing (conflict resolved, which doe snot 
+                                 change anything) 
+
+2626 2.3.37 02-12-20 claudeduhr: fixed args name clash 
+
 2614 2.3.36 28-11-19 fuks:       Small in InSurGe and with the interaction 
                                  orders in the UFO interface 
 

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -1,5 +1,7 @@
 Update notes for FeynRules 2.3.x
 
+2633 2.3.43 23-02-21 degrande:   bug fix for tadpole renormalisation 
+
 2631 2.3.42 14-02-21 claudeduhr: fixed bug in numQ for exponentials 
 
 2628 2.3.41 09-12-20 claudeduhr: fixed merge conflict 


### PR DESCRIPTION
Thank you for maintaining the useful repo.

This PR aims to automatise the synchronisation with the original FeynRules 2.3.x distribution, by utilising [cron scheduling on GitHub Actions](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events). The action tries to download the distribution at 0:00 UTC every day, and push it if any changes happen. Commit messages are constructed as `v{FR$Version} ({FR$VersionDate})`.

The action should work without any additional configurations (such as giving a GitHub token as an encrypted secret), see also [this example](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token). The cryptic `user.name` and `user.email` for the push come from [here](https://github.community/t/github-actions-bot-email-address/17204/5).

It also contains commits for the recent 3 versions (2.3.41, 2.3.42, and 2.3.43).